### PR TITLE
fix: Don't ignore rows with same modified timestamp as previous row

### DIFF
--- a/tap_dynamics/sync.py
+++ b/tap_dynamics/sync.py
@@ -65,7 +65,7 @@ def sync_stream(service, catalog, state, start_date, stream, mdata):
                     dict_record[prop_name] = value
 
                 if MODIFIED_DATE_FIELD in dict_record:
-                    if dict_record[MODIFIED_DATE_FIELD] > max_modified:
+                    if dict_record[MODIFIED_DATE_FIELD] >= max_modified:
                         max_modified = dict_record[MODIFIED_DATE_FIELD]
                     else:
                         continue


### PR DESCRIPTION
Closes #5